### PR TITLE
French translation fix

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -61,7 +61,7 @@
                 $scope.lang = "it"
             } else if (lang == "fr") {
                 $scope.texts = texts[2]
-                $scope.lang = "ar"
+                $scope.lang = "fr"
             } else if (lang == "ar") {
                 $scope.texts = texts[3]
                 $scope.lang = "ar"

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
                 $scope.lang = "it"
             } else if (lang == "fr") {
                 $scope.texts = texts[2]
-                $scope.lang = "ar"
+                $scope.lang = "fr"
             } else if (lang == "ar") {
                 $scope.texts = texts[3]
                 $scope.lang = "ar"


### PR DESCRIPTION
The $scope.lang under french was set to "ar" instead of "fr" on both the compatibility and index files